### PR TITLE
Fix NullReference while in double prefab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,25 @@
 # Changelog
 
+## [1.0.5] - 2021-06-22
+### Fixed
+- Fixed NullReference while in prefab mode in other prefab
+
 ## [1.0.4] - 2021-06-22
 ### Added
--Add OnEnable Refresh
+- Add OnEnable Refresh
 
 ## [1.0.3] - 2021-06-20
 ### Added
--Add Menu item
+- Add Menu item
 
 ## [1.0.2] - 2021-05-31
 ### Added
--Add change event
+- Add change event
 
 ## [1.0.1] - 2021-05-31
 ### Added
--Add iPhone bottom fix
+- Add iPhone bottom fix
 
 ## [1.0.0] - 2021-05-31
 ### Added
--Release
+- Release

--- a/Runtime/SafeArea.cs
+++ b/Runtime/SafeArea.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -7,7 +7,6 @@ using UnityEngine.UI;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
-
 
 namespace AS.SafeArea
 {
@@ -20,12 +19,13 @@ namespace AS.SafeArea
         public bool top = true;
         public bool bottom = true;
         public FloatRectOffset padding, minBorder;
+
         [Space]
         public float fixIphoneBottomFactor = 0.41666f;
 
         public delegate void OnChange(Rect rect);
-        public event OnChange onSafeAreaChange;
 
+        public event OnChange onSafeAreaChange;
 
         RectTransform rectTransform;
         LayoutGroup targetLayoutGroup;
@@ -53,6 +53,7 @@ namespace AS.SafeArea
         static public void CreateSafeArea(MenuCommand menuCommand)
         {
             GameObject parent = menuCommand.context as GameObject;
+
             if (parent)
             {
                 GameObject go = new GameObject("SafeArea");
@@ -135,7 +136,6 @@ namespace AS.SafeArea
                 ApplySafeArea(r);
 
                 onSafeAreaChange?.Invoke(r);
-
             }
         }
 
@@ -157,21 +157,25 @@ namespace AS.SafeArea
                 {
                     case ScreenOrientation.Portrait:
                         r.yMin = r.yMin * fixIphoneBottomFactor;
+
                         break;
                     case ScreenOrientation.PortraitUpsideDown:
                         r.yMax = Screen.height + (r.yMax - Screen.height) * fixIphoneBottomFactor;
+
                         break;
                     case ScreenOrientation.LandscapeRight:
                         r.xMin = r.xMin * fixIphoneBottomFactor;
+
                         break;
                     case ScreenOrientation.LandscapeLeft:
                         r.xMax = Screen.width + (r.xMax - Screen.width) * fixIphoneBottomFactor;
+
                         break;
                 }
-
             }
 
-            Vector2 size = GetComponentInParent<Canvas>().GetComponent<RectTransform>().sizeDelta;
+            if (!(GetComponentInParent<Canvas>() is {transform: RectTransform rect})) return r;
+            var size = rect.sizeDelta;
 
 
             float xScale = size.x / (1.0f * Screen.width);
@@ -188,17 +192,13 @@ namespace AS.SafeArea
 
         void ApplySafeArea(Rect r)
         {
-            if (!top)
-                r.yMax = Screen.height;
+            if (!top) r.yMax = Screen.height;
 
-            if (!bottom)
-                r.yMin = 0;
+            if (!bottom) r.yMin = 0;
 
-            if (!right)
-                r.xMax = Screen.width;
+            if (!right) r.xMax = Screen.width;
 
-            if (!left)
-                r.xMin = 0;
+            if (!left) r.xMin = 0;
 
             if (variant == Variant.anchorPosition)
             {
@@ -229,9 +229,11 @@ namespace AS.SafeArea
         void SetRectPadding(Rect r)
         {
             if (!targetLayoutGroup) targetLayoutGroup = GetComponent<LayoutGroup>();
+
             if (!targetLayoutGroup)
             {
                 this.enabled = false;
+
                 throw new System.Exception("LayoutGroup not found");
             }
 
@@ -248,7 +250,6 @@ namespace AS.SafeArea
             targetLayoutGroup.padding.right = Mathf.RoundToInt((Screen.width - r.xMax) * xScale);
 
             LayoutRebuilder.MarkLayoutForRebuild(rectTransform);
-
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.soprachevak.safe-area",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "displayName": "Safe area",
   "description": "Safe area component for anchored and layout padding",
   "dependencies": {},


### PR DESCRIPTION
Added Null check for `GetComponentInParent<Canvas>`.

Reason:
When SafeArea was in prefab which was in another prefab for some reason `GetComponentInParent<Canvas>` returned `null`l